### PR TITLE
Use scratch for the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,7 @@ FROM scratch
 
 WORKDIR /app
 
-# System setup
-COPY /bin/sh /bin/
-COPY /lib/x86_64-linux-gnu/libnss_files.so.2 /lib/x86_64-linux-gnu/libnss_dns.so.2 /lib/x86_64-linux-gnu/
-COPY /lib64/ld-linux-x86-64.so.2 /lib64/
-COPY /etc/protocols /etc/services /etc/
-COPY /usr/lib/x86_64-linux-gnu/gconv/UTF-16.so /usr/lib/x86_64-linux-gnu/gconv/UTF-32.so /usr/lib/x86_64-linux-gnu/gconv/UTF-7.so /usr/lib/x86_64-linux-gnu/gconv/gconv-modules /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache /usr/lib/x86_64-linux-gnu/gconv/
-
-# Specific deps
+COPY ./root /
 COPY ./bin/lib/. /lib/x86_64-linux-gnu/
 COPY ./impatience.dhall /app/impatience.dhall
 COPY ./bin/impatience-exe /app/impatience-exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fpco/haskell-scratch:integer-gmp
 
 WORKDIR /app
-COPY ./bin/lib/. /usr/lib/x86_64-linux-gnu/
+COPY ./bin/lib/. /lib/x86_64-linux-gnu/
 COPY ./impatience.dhall /app/impatience.dhall
 COPY ./bin/impatience-exe /app/impatience-exe
 ENV PATH="/app:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM fpco/haskell-scratch:integer-gmp
+FROM scratch
 
 WORKDIR /app
+
+# System setup
+COPY /bin/sh /bin/
+COPY /lib/x86_64-linux-gnu/libnss_files.so.2 /lib/x86_64-linux-gnu/libnss_dns.so.2 /lib/x86_64-linux-gnu/
+COPY /lib64/ld-linux-x86-64.so.2 /lib64/
+COPY /etc/protocols /etc/services /etc/
+COPY /usr/lib/x86_64-linux-gnu/gconv/UTF-16.so /usr/lib/x86_64-linux-gnu/gconv/UTF-32.so /usr/lib/x86_64-linux-gnu/gconv/UTF-7.so /usr/lib/x86_64-linux-gnu/gconv/gconv-modules /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache /usr/lib/x86_64-linux-gnu/gconv/
+
+# Specific deps
 COPY ./bin/lib/. /lib/x86_64-linux-gnu/
 COPY ./impatience.dhall /app/impatience.dhall
 COPY ./bin/impatience-exe /app/impatience-exe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,13 +56,14 @@ stages:
         stack setup
       displayName: Install GHC
     - script: |
+        sudo apt-get update && sudo apt-get upgrade
         sudo apt-get install -y libpq-dev
         export PATH=$HOME/.local/bin:$PATH
         mkdir -p bin
         mkdir -p bin/lib
         curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s src
         stack build --copy-bins --local-bin-path ./bin
-        ldd --version ./bin/impatience-exe
+        ldd --version
         ldd ./bin/impatience-exe | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' bin/lib
       displayName: Build Non-Tests
     - publish: bin/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     steps:
     - task: CacheBeta@0
       displayName: Download stack root cache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,8 +118,7 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - script: |
-        TAG=$(wget -q -O - https://github.com/purescript/purescript/releases/latest --server-response --max-redirect 0 2>&1 | sed -n -e 's/.*Location:.*tag\///p')
-        wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
+        wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/latest/download/linux64.tar.gz
         tar -xvf $HOME/purescript.tar.gz -C $HOME/
         chmod a+x $HOME/purescript
         PATH=$HOME/purescript:$PATH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-16.04'
     steps:
     - task: CacheBeta@0
       displayName: Download stack root cache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,6 @@ stages:
         stack setup
       displayName: Install GHC
     - script: |
-        sudo apt-get update && sudo apt-get upgrade
         sudo apt-get install -y libpq-dev
         export PATH=$HOME/.local/bin:$PATH
         mkdir -p bin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
     - task: CacheBeta@0
       displayName: Download stack root cache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
   jobs:
   - job: ApiTest
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     steps:
     - checkout: none
     - download: current
@@ -114,7 +114,7 @@ stages:
         testResultsFiles: 'tasty-results.xml'
   - job: SiteTest
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     steps:
     - script: |
         wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/latest/download/linux64.tar.gz
@@ -127,7 +127,7 @@ stages:
         spago test
   - job: ImageTest
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     steps:
     - download: current
       artifact: test-exe
@@ -142,6 +142,7 @@ stages:
         echo "COPY bin/impatience-test /app/impatience-test" >> Dockerfile.test
         echo "ENV TASTY_ANSI_TRICKS=false" >> Dockerfile.test
         echo "ENV TASTY_HIDE_SUCCESSES=true" >> Dockerfile.test
+        ./container-root.sh
         docker build -t "test-image" -f Dockerfile.test .
         docker run test-image impatience-test
       displayName: Execute Tests In Image
@@ -153,7 +154,7 @@ stages:
     displayName: Push image to registry
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     steps:
     - download: current
       artifact: exe
@@ -164,6 +165,7 @@ stages:
         curl -sSL https://github.com/upx/upx/releases/download/v3.95/upx-3.95-amd64_linux.tar.xz -o upx.tar.xz
         tar -xf upx.tar.xz
         ./upx-3.95-amd64_linux/upx --best --ultra-brute bin/impatience-exe
+        ./container-root.sh
       displayName: Compress executable
     - task: Docker@2
       displayName: Build and Push Image
@@ -183,7 +185,7 @@ stages:
   - deployment: Deploy
     displayName: Deploy to k8s
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-18.04'
     environment: 'impatience.default'
     strategy:
       runOnce:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,7 @@ stages:
       displayName: Extract stack work cache
       condition: eq(variables.WORK_CACHE_HIT, 'true')
     - script: |
-        TAG=$(wget -q -O - https://github.com/purescript/purescript/releases/latest --server-response --max-redirect 0 2>&1 | sed -n -e 's/.*Location:.*tag\///p')
-        wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
+        wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/latest/download/linux64.tar.gz
         tar -xvf $HOME/purescript.tar.gz -C $HOME/
         chmod a+x $HOME/purescript
         PATH=$HOME/purescript:$PATH

--- a/container-root.sh
+++ b/container-root.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Makes the root dir for the deployment container
+
+mkdir -p root/bin && cp /bin/sh root/bin/
+mkdir -p root/lib/x86_64-linux-gnu && cp /lib/x86_64-linux-gnu/{libnss_files.so.2,libnss_dns.so.2} root/lib/x86_64-linux-gnu/
+mkdir -p root/lib64 && cp /lib64/ld-linux-x86-64.so.2 root/lib64/
+mkdir -p root/etc && cp /etc/{protocols,services} root/etc/
+mkdir -p root/usr/lib/x86_64-linux-gnu/gconv && cp /usr/lib/x86_64-linux-gnu/gconv/{UTF-16.so,UTF-32.so,UTF-7.so,gconv-modules,gconv-modules.cache} root/usr/lib/x86_64-linux-gnu/gconv/

--- a/package.yaml
+++ b/package.yaml
@@ -59,9 +59,6 @@ executables:
     - -Wall
     - -Werror
     - -O2
-    - -static
-    cc-options: -static
-    ld-options: -static -pthread
     dependencies:
       - impatience
 

--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,9 @@ executables:
     - -Wall
     - -Werror
     - -O2
+    - -static
+    cc-options: -static
+    ld-options: -static -pthread
     dependencies:
       - impatience
 


### PR DESCRIPTION
The pipeline was failing during image tests because the libraries were linked against a different glibc version (introduced because the build host agent was changed).
Although there were no changes in this repo, previously successful builds then failed.

To increase reproducibility, the entire image is built here now.